### PR TITLE
Update collectd.py

### DIFF
--- a/collectd.py
+++ b/collectd.py
@@ -5,7 +5,10 @@ import struct
 import logging
 import traceback
 from functools import wraps
-from Queue import Queue, Empty
+try:
+   from Queue import Queue, Empty
+except ImportError:
+   from queue import Queue, Empty
 from collections import defaultdict
 from threading import RLock, Thread, Semaphore
 


### PR DESCRIPTION
Add Python3 support

```
Python 3.7.8 | packaged by conda-forge | (default, Jul 31 2020, 02:25:08) 
[GCC 7.5.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import collectd
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/opt/conda/lib/python3.7/site-packages/collectd.py", line 8, in <module>
    from Queue import Queue, Empty
ModuleNotFoundError: No module named 'Queue'
```